### PR TITLE
feat: implement smart polling scheduler (Issue #8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,16 @@ POLL_END_HOUR=23
 FORWARD_WINDOW_DAYS=5
 
 # ==============================================================================
+# SMART POLLING SCHEDULE
+# ==============================================================================
+
+# Hours before a session to start active polling (default: 96)
+APPROACH_WINDOW_HOURS=96
+
+# Maximum hours between polls regardless of schedule (default: 12)
+MAX_SLEEP_HOURS=12
+
+# ==============================================================================
 # ALERT THRESHOLDS
 # ==============================================================================
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,8 @@ export interface Config {
   pollStartHour: number
   pollEndHour: number
   forwardWindowDays: number
+  approachWindowHours: number
+  maxSleepHours: number
   minGoalies: number
   minPlayersRegistered: number
   playerSpotsUrgent: number
@@ -27,6 +29,8 @@ export function loadConfig(): Config {
     pollStartHour: parseIntOrDefault(process.env.POLL_START_HOUR, 6),
     pollEndHour: parseIntOrDefault(process.env.POLL_END_HOUR, 23),
     forwardWindowDays: parseIntOrDefault(process.env.FORWARD_WINDOW_DAYS, 5),
+    approachWindowHours: parseIntOrDefault(process.env.APPROACH_WINDOW_HOURS, 96),
+    maxSleepHours: parseIntOrDefault(process.env.MAX_SLEEP_HOURS, 12),
     minGoalies: parseIntOrDefault(process.env.MIN_GOALIES, 1),
     minPlayersRegistered: parseIntOrDefault(process.env.MIN_PLAYERS_REGISTERED, 10),
     playerSpotsUrgent: parseIntOrDefault(process.env.PLAYER_SPOTS_URGENT, 4),
@@ -65,6 +69,14 @@ export function validateConfig(config: Config): void {
 
   if (config.forwardWindowDays <= 0) {
     throw new Error('forwardWindowDays must be > 0')
+  }
+
+  if (config.approachWindowHours <= 0) {
+    throw new Error('approachWindowHours must be > 0')
+  }
+
+  if (config.maxSleepHours <= 0) {
+    throw new Error('maxSleepHours must be > 0')
   }
 
   if (config.minGoalies < 0) {

--- a/src/poll-schedule.ts
+++ b/src/poll-schedule.ts
@@ -1,0 +1,216 @@
+import type { SessionState } from './evaluator'
+
+export interface PollScheduleResult {
+  delayMs: number
+  reason: 'approach' | 'sleep' | 'fallback'
+  scheduleLog: string
+  wakeLog: string
+}
+
+interface ScheduleConfig {
+  approachWindowHours: number
+  maxSleepHours: number
+  pollIntervalMinutes: number
+  pollIntervalAcceleratedMinutes: number
+  pollStartHour: number
+  pollEndHour: number
+}
+
+/**
+ * Parse a session date+time (ET wall-clock) into a UTC Date object.
+ * Handles both EST (UTC-5) and EDT (UTC-4) automatically.
+ */
+export function parseSessionTimeET(dateStr: string, timeStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  const [hours, minutes] = timeStr.split(':').map(Number)
+
+  // Try EST (UTC-5) first, then EDT (UTC-4)
+  const estCandidate = new Date(Date.UTC(year, month - 1, day, hours + 5, minutes))
+  const estCheck = getETComponents(estCandidate)
+
+  if (estCheck.hour === hours && estCheck.minute === minutes) {
+    return estCandidate
+  }
+
+  return new Date(Date.UTC(year, month - 1, day, hours + 4, minutes))
+}
+
+/**
+ * Find the earliest future session time from state.
+ * Returns null if no future sessions exist.
+ */
+export function getNextSessionTime(sessions: SessionState[], now: Date): Date | null {
+  let earliest: Date | null = null
+
+  for (const s of sessions) {
+    const sessionTime = parseSessionTimeET(s.session.date, s.session.time)
+    if (sessionTime <= now) continue
+    if (earliest === null || sessionTime < earliest) {
+      earliest = sessionTime
+    }
+  }
+
+  return earliest
+}
+
+/**
+ * Calculate the optimal delay until the next poll based on session proximity.
+ *
+ * - Inside approach window: use normal/accelerated interval
+ * - Outside approach window: sleep until approach window opens (capped at maxSleepHours)
+ * - No sessions: sleep maxSleepHours (fallback)
+ * - All wake times are clamped to active hours (pollStartHour/pollEndHour ET)
+ */
+export function calculateNextPollDelay(
+  now: Date,
+  nextSessionTimeUTC: Date | null,
+  config: ScheduleConfig,
+  accelerated: boolean
+): PollScheduleResult {
+  const maxSleepMs = config.maxSleepHours * 60 * 60 * 1000
+
+  // No sessions: fallback to max sleep
+  if (nextSessionTimeUTC === null) {
+    const fallbackWake = new Date(now.getTime() + maxSleepMs)
+    const clampedWake = clampToActiveHoursET(fallbackWake, config.pollStartHour, config.pollEndHour)
+    const delayMs = clampedWake.getTime() - now.getTime()
+
+    return {
+      delayMs,
+      reason: 'fallback',
+      scheduleLog: `💤 No upcoming sessions found. Fallback wake: ${formatDateET(clampedWake)} (max ${config.maxSleepHours}h).`,
+      wakeLog: `⏰ Max sleep reached (${config.maxSleepHours}h). Running fallback poll.`,
+    }
+  }
+
+  // Calculate approach window open time
+  const approachWindowOpenUTC = new Date(
+    nextSessionTimeUTC.getTime() - config.approachWindowHours * 60 * 60 * 1000
+  )
+
+  // Inside approach window: use normal/accelerated interval
+  if (now.getTime() >= approachWindowOpenUTC.getTime()) {
+    const intervalMinutes = accelerated
+      ? config.pollIntervalAcceleratedMinutes
+      : config.pollIntervalMinutes
+    const intervalMs = intervalMinutes * 60 * 1000
+
+    const wakeTime = new Date(now.getTime() + intervalMs)
+    const clampedWake = clampToActiveHoursET(wakeTime, config.pollStartHour, config.pollEndHour)
+    const delayMs = clampedWake.getTime() - now.getTime()
+
+    const modeLabel = accelerated ? 'accelerated - FILLING_FAST detected' : 'normal'
+
+    return {
+      delayMs,
+      reason: 'approach',
+      scheduleLog: `⏰ Approach window open for ${formatDateET(nextSessionTimeUTC)}. Next poll in ${intervalMinutes} minutes (${modeLabel}).`,
+      wakeLog: `⏰ Polling (approach window for ${formatDateET(nextSessionTimeUTC)}).`,
+    }
+  }
+
+  // Outside approach window: sleep until approach opens or max sleep
+  const maxWakeUTC = new Date(now.getTime() + maxSleepMs)
+  const useFallback = approachWindowOpenUTC.getTime() > maxWakeUTC.getTime()
+  const targetWake = useFallback ? maxWakeUTC : approachWindowOpenUTC
+  const clampedWake = clampToActiveHoursET(targetWake, config.pollStartHour, config.pollEndHour)
+  const delayMs = clampedWake.getTime() - now.getTime()
+
+  const hoursUntilApproach = Math.round(
+    (approachWindowOpenUTC.getTime() - now.getTime()) / (60 * 60 * 1000)
+  )
+
+  if (useFallback) {
+    return {
+      delayMs,
+      reason: 'fallback',
+      scheduleLog: `💤 No sessions in approach window. Next session: ${formatDateET(nextSessionTimeUTC)}. Approach window opens in ${hoursUntilApproach}h. Fallback wake: ${formatDateET(clampedWake)} (max ${config.maxSleepHours}h).`,
+      wakeLog: `⏰ Max sleep reached (${config.maxSleepHours}h). Running fallback poll.`,
+    }
+  }
+
+  return {
+    delayMs,
+    reason: 'sleep',
+    scheduleLog: `💤 No sessions in approach window. Next session: ${formatDateET(nextSessionTimeUTC)}. Sleeping until ${formatDateET(clampedWake)} (approach window opens in ${hoursUntilApproach}h). Fallback wake: ${formatDateET(maxWakeUTC)} (max ${config.maxSleepHours}h).`,
+    wakeLog: `⏰ Approach window open for ${formatDateET(nextSessionTimeUTC)}. Resuming normal polling.`,
+  }
+}
+
+/**
+ * Format a UTC Date as ET for logging.
+ * Example: "Wed, Feb 25, 7:30 PM ET"
+ */
+export function formatDateET(date: Date): string {
+  return (
+    date.toLocaleString('en-US', {
+      timeZone: 'America/New_York',
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    }) + ' ET'
+  )
+}
+
+/**
+ * Get date/time components in ET from a UTC Date.
+ */
+function getETComponents(date: Date): {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+} {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hourCycle: 'h23',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).formatToParts(date)
+
+  return {
+    year: parseInt(parts.find((p) => p.type === 'year')!.value),
+    month: parseInt(parts.find((p) => p.type === 'month')!.value),
+    day: parseInt(parts.find((p) => p.type === 'day')!.value),
+    hour: parseInt(parts.find((p) => p.type === 'hour')!.value),
+    minute: parseInt(parts.find((p) => p.type === 'minute')!.value),
+  }
+}
+
+/**
+ * Clamp a wake time to the next active hours window in ET.
+ * If the wake time falls outside pollStartHour–pollEndHour ET,
+ * push it to the next pollStartHour (same day or next day).
+ */
+function clampToActiveHoursET(wakeTime: Date, pollStartHour: number, pollEndHour: number): Date {
+  const et = getETComponents(wakeTime)
+
+  if (et.hour >= pollStartHour && et.hour <= pollEndHour) {
+    return wakeTime
+  }
+
+  // Outside active hours — push to next pollStartHour in ET
+  let targetDateStr: string
+  if (et.hour < pollStartHour) {
+    // Before active hours today — use pollStartHour today
+    targetDateStr = `${et.year}-${pad(et.month)}-${pad(et.day)}`
+  } else {
+    // After active hours — use pollStartHour tomorrow
+    const nextDay = new Date(wakeTime.getTime() + 24 * 60 * 60 * 1000)
+    const nextET = getETComponents(nextDay)
+    targetDateStr = `${nextET.year}-${pad(nextET.month)}-${pad(nextET.day)}`
+  }
+
+  return parseSessionTimeET(targetDateStr, `${pad(pollStartHour)}:00`)
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -24,6 +24,8 @@ describe('config', () => {
       expect(config.pollStartHour).toBe(6)
       expect(config.pollEndHour).toBe(23)
       expect(config.forwardWindowDays).toBe(5)
+      expect(config.approachWindowHours).toBe(96)
+      expect(config.maxSleepHours).toBe(12)
       expect(config.minGoalies).toBe(1)
       expect(config.minPlayersRegistered).toBe(10)
       expect(config.playerSpotsUrgent).toBe(4)
@@ -64,6 +66,16 @@ describe('config', () => {
       const config = loadConfig()
 
       expect(config.forwardWindowDays).toBe(7)
+    })
+
+    it('loads custom smart polling config from env', () => {
+      process.env.APPROACH_WINDOW_HOURS = '72'
+      process.env.MAX_SLEEP_HOURS = '8'
+
+      const config = loadConfig()
+
+      expect(config.approachWindowHours).toBe(72)
+      expect(config.maxSleepHours).toBe(8)
     })
 
     it('loads custom alert thresholds from env', () => {
@@ -109,33 +121,14 @@ describe('config', () => {
 
   describe('validateConfig', () => {
     it('accepts valid config with all defaults', () => {
-      const config: Config = {
-        pollIntervalMinutes: 60,
-        pollIntervalAcceleratedMinutes: 30,
-        pollStartHour: 6,
-        pollEndHour: 23,
-        forwardWindowDays: 5,
-        minGoalies: 1,
-        minPlayersRegistered: 10,
-        playerSpotsUrgent: 4,
-        slackWebhookUrl: undefined,
-      }
+      const config = loadConfig()
 
       expect(() => validateConfig(config)).not.toThrow()
     })
 
     it('accepts valid config with Slack webhook', () => {
-      const config: Config = {
-        pollIntervalMinutes: 60,
-        pollIntervalAcceleratedMinutes: 30,
-        pollStartHour: 6,
-        pollEndHour: 23,
-        forwardWindowDays: 5,
-        minGoalies: 1,
-        minPlayersRegistered: 10,
-        playerSpotsUrgent: 4,
-        slackWebhookUrl: 'https://hooks.slack.com/test',
-      }
+      const config = loadConfig()
+      config.slackWebhookUrl = 'https://hooks.slack.com/test'
 
       expect(() => validateConfig(config)).not.toThrow()
     })
@@ -188,6 +181,20 @@ describe('config', () => {
       config.forwardWindowDays = 0
 
       expect(() => validateConfig(config)).toThrow('forwardWindowDays must be > 0')
+    })
+
+    it('throws when approachWindowHours is zero', () => {
+      const config = loadConfig()
+      config.approachWindowHours = 0
+
+      expect(() => validateConfig(config)).toThrow('approachWindowHours must be > 0')
+    })
+
+    it('throws when maxSleepHours is zero', () => {
+      const config = loadConfig()
+      config.maxSleepHours = 0
+
+      expect(() => validateConfig(config)).toThrow('maxSleepHours must be > 0')
     })
 
     it('throws when minGoalies is negative', () => {

--- a/tests/evaluator.test.ts
+++ b/tests/evaluator.test.ts
@@ -11,6 +11,8 @@ describe('evaluator', () => {
     pollStartHour: 6,
     pollEndHour: 23,
     forwardWindowDays: 5,
+    approachWindowHours: 96,
+    maxSleepHours: 12,
     minGoalies: 1,
     minPlayersRegistered: 10,
     playerSpotsUrgent: 4,
@@ -20,8 +22,8 @@ describe('evaluator', () => {
   }
 
   const createSession = (overrides: Partial<Session> = {}): Session => ({
-    date: '2026-02-20',
-    dayOfWeek: 'Friday',
+    date: '2026-02-25',
+    dayOfWeek: 'Wednesday',
     time: '06:00',
     timeLabel: '6:00am - 7:10am',
     eventName: '(PLAYERS) ADULT Pick Up MORNINGS',
@@ -397,7 +399,7 @@ describe('evaluator', () => {
       expect(alerts[0]).toHaveProperty('session')
       expect(alerts[0]).toHaveProperty('message')
       expect(alerts[0]).toHaveProperty('registrationUrl')
-      expect(alerts[0].registrationUrl).toContain('2026-02-20')
+      expect(alerts[0].registrationUrl).toContain('2026-02-25')
     })
 
     it('fires only FILLING_FAST when both FILLING_FAST and OPPORTUNITY conditions are met', () => {
@@ -812,7 +814,7 @@ describe('evaluator', () => {
 
     it('handles state for different session (date/time mismatch)', () => {
       const session = createSession({
-        date: '2026-02-20',
+        date: '2026-02-25',
         time: '06:00',
         playersRegistered: 10,
         playersMax: 24,

--- a/tests/poll-schedule.test.ts
+++ b/tests/poll-schedule.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateNextPollDelay,
+  getNextSessionTime,
+  parseSessionTimeET,
+} from '../src/poll-schedule'
+import type { SessionState } from '../src/evaluator'
+import type { Session } from '../src/parser'
+
+// February 2026 is EST (UTC-5)
+// Helpers for readable test dates:
+// 10:00 AM ET = 15:00 UTC
+// 7:30 PM ET  = 00:30 UTC next day
+// 6:00 AM ET  = 11:00 UTC
+// 3:00 AM ET  = 08:00 UTC
+
+function makeSession(date: string, time: string): Session {
+  return {
+    date,
+    dayOfWeek: 'Wednesday',
+    time,
+    timeLabel: '7:00pm - 8:10pm',
+    eventName: '(PLAYERS) ADULT Pick Up',
+    playersRegistered: 10,
+    playersMax: 24,
+    goaliesRegistered: 1,
+    goaliesMax: 4,
+    isFull: false,
+    price: 0,
+  }
+}
+
+function makeSessionState(date: string, time: string): SessionState {
+  return {
+    session: makeSession(date, time),
+    lastAlertType: null,
+    lastAlertAt: null,
+    lastPlayerCount: null,
+    isRegistered: false,
+    userResponse: null,
+    userRespondedAt: null,
+    remindAfter: null,
+  }
+}
+
+const defaultConfig = {
+  approachWindowHours: 96,
+  maxSleepHours: 12,
+  pollIntervalMinutes: 60,
+  pollIntervalAcceleratedMinutes: 30,
+  pollStartHour: 6,
+  pollEndHour: 23,
+}
+
+describe('parseSessionTimeET', () => {
+  it('converts EST date+time to correct UTC Date', () => {
+    // Feb 20, 2026 7:30 PM ET (EST, UTC-5) = Feb 21, 2026 00:30 UTC
+    const result = parseSessionTimeET('2026-02-20', '19:30')
+
+    expect(result.getUTCFullYear()).toBe(2026)
+    expect(result.getUTCMonth()).toBe(1) // 0-indexed
+    expect(result.getUTCDate()).toBe(21)
+    expect(result.getUTCHours()).toBe(0)
+    expect(result.getUTCMinutes()).toBe(30)
+  })
+
+  it('converts morning EST time correctly', () => {
+    // Feb 20, 2026 6:00 AM ET (EST, UTC-5) = Feb 20, 2026 11:00 UTC
+    const result = parseSessionTimeET('2026-02-20', '06:00')
+
+    expect(result.getUTCFullYear()).toBe(2026)
+    expect(result.getUTCMonth()).toBe(1)
+    expect(result.getUTCDate()).toBe(20)
+    expect(result.getUTCHours()).toBe(11)
+    expect(result.getUTCMinutes()).toBe(0)
+  })
+
+  it('handles EDT (summer) correctly', () => {
+    // Jul 15, 2026 7:30 PM ET (EDT, UTC-4) = Jul 15, 2026 23:30 UTC
+    const result = parseSessionTimeET('2026-07-15', '19:30')
+
+    expect(result.getUTCFullYear()).toBe(2026)
+    expect(result.getUTCMonth()).toBe(6)
+    expect(result.getUTCDate()).toBe(15)
+    expect(result.getUTCHours()).toBe(23)
+    expect(result.getUTCMinutes()).toBe(30)
+  })
+})
+
+describe('getNextSessionTime', () => {
+  it('returns null when no sessions', () => {
+    const now = new Date('2026-02-20T15:00:00Z')
+    const result = getNextSessionTime([], now)
+
+    expect(result).toBeNull()
+  })
+
+  it('returns earliest future session time', () => {
+    const now = new Date('2026-02-20T15:00:00Z') // 10 AM ET
+    const sessions = [
+      makeSessionState('2026-02-23', '19:30'), // Mon 7:30 PM ET
+      makeSessionState('2026-02-21', '07:00'), // Sat 7:00 AM ET (earlier)
+      makeSessionState('2026-02-25', '19:30'), // Wed 7:30 PM ET
+    ]
+
+    const result = getNextSessionTime(sessions, now)
+
+    // Earliest future: Feb 21 7:00 AM ET = Feb 21 12:00 UTC
+    expect(result).not.toBeNull()
+    expect(result!.getUTCDate()).toBe(21)
+    expect(result!.getUTCHours()).toBe(12)
+  })
+
+  it('skips past sessions', () => {
+    const now = new Date('2026-02-22T15:00:00Z') // Feb 22, 10 AM ET
+    const sessions = [
+      makeSessionState('2026-02-20', '19:30'), // past
+      makeSessionState('2026-02-21', '07:00'), // past
+      makeSessionState('2026-02-25', '19:30'), // future
+    ]
+
+    const result = getNextSessionTime(sessions, now)
+
+    // Only Feb 25 is future: Feb 26 00:30 UTC
+    expect(result).not.toBeNull()
+    expect(result!.getUTCDate()).toBe(26)
+    expect(result!.getUTCHours()).toBe(0)
+    expect(result!.getUTCMinutes()).toBe(30)
+  })
+
+  it('returns null when all sessions are in the past', () => {
+    const now = new Date('2026-02-28T15:00:00Z')
+    const sessions = [
+      makeSessionState('2026-02-20', '19:30'),
+      makeSessionState('2026-02-21', '07:00'),
+    ]
+
+    const result = getNextSessionTime(sessions, now)
+
+    expect(result).toBeNull()
+  })
+})
+
+describe('calculateNextPollDelay', () => {
+  it('returns fallback delay when no sessions', () => {
+    const now = new Date('2026-02-20T15:00:00Z') // 10 AM ET
+
+    const result = calculateNextPollDelay(now, null, defaultConfig, false)
+
+    expect(result.delayMs).toBe(12 * 60 * 60 * 1000) // 12h
+    expect(result.reason).toBe('fallback')
+  })
+
+  it('sleeps until approach window when session is outside window', () => {
+    const now = new Date('2026-02-20T15:00:00Z') // Feb 20, 10 AM ET
+    // Session: Feb 24, 7 PM ET = Feb 25 00:00 UTC
+    // 96h approach window opens: Feb 21, 00:00 UTC (Feb 20 7 PM ET) — 9h from now
+    // 9h < 12h max sleep, so sleep until approach window
+    const nextSession = parseSessionTimeET('2026-02-24', '19:00')
+
+    const result = calculateNextPollDelay(now, nextSession, defaultConfig, false)
+
+    const expectedMs = 9 * 60 * 60 * 1000
+    expect(result.delayMs).toBe(expectedMs)
+    expect(result.reason).toBe('sleep')
+  })
+
+  it('uses normal interval when inside approach window', () => {
+    const now = new Date('2026-02-20T15:00:00Z') // Feb 20, 10 AM ET
+    // Session: Feb 23, 7 PM ET — 3 days away, within 96h approach window
+    const nextSession = parseSessionTimeET('2026-02-23', '19:00')
+
+    const result = calculateNextPollDelay(now, nextSession, defaultConfig, false)
+
+    expect(result.delayMs).toBe(60 * 60 * 1000) // 60 min normal
+    expect(result.reason).toBe('approach')
+  })
+
+  it('uses accelerated interval when FILLING_FAST in approach window', () => {
+    const now = new Date('2026-02-20T15:00:00Z')
+    const nextSession = parseSessionTimeET('2026-02-23', '19:00')
+
+    const result = calculateNextPollDelay(now, nextSession, defaultConfig, true)
+
+    expect(result.delayMs).toBe(30 * 60 * 1000) // 30 min accelerated
+    expect(result.reason).toBe('approach')
+  })
+
+  it('uses normal interval for session 2 hours away', () => {
+    const now = new Date('2026-02-20T15:00:00Z') // 10 AM ET
+    // Session at noon ET = 17:00 UTC, 2 hours from now
+    const nextSession = parseSessionTimeET('2026-02-20', '12:00')
+
+    const result = calculateNextPollDelay(now, nextSession, defaultConfig, false)
+
+    expect(result.delayMs).toBe(60 * 60 * 1000)
+    expect(result.reason).toBe('approach')
+  })
+
+  it('caps sleep at maxSleepHours when approach window is far away', () => {
+    const now = new Date('2026-02-20T15:00:00Z') // Feb 20, 10 AM ET
+    // Session: Mar 1, 7 PM ET — ~9 days away
+    // Approach window opens ~5 days from now, well beyond 12h max sleep
+    const nextSession = parseSessionTimeET('2026-03-01', '19:00')
+
+    const result = calculateNextPollDelay(now, nextSession, defaultConfig, false)
+
+    // Should cap at max sleep (12h), clamped to active hours
+    // now + 12h = Feb 21 03:00 UTC = Feb 20 10:00 PM ET — within active hours
+    expect(result.delayMs).toBe(12 * 60 * 60 * 1000)
+    expect(result.reason).toBe('fallback')
+  })
+
+  it('clamps wake time to pollStartHour when approach opens before active hours', () => {
+    // now: Feb 22, 1 AM ET = Feb 22 06:00 UTC
+    const now = new Date('2026-02-22T06:00:00Z')
+    // Session: Feb 26, 3 AM ET = Feb 26 08:00 UTC
+    // Approach window (96h): opens Feb 22, 3 AM ET = Feb 22 08:00 UTC (2h from now)
+    // But 3 AM ET < 6 AM pollStartHour → clamp to 6 AM ET = Feb 22 11:00 UTC (5h from now)
+    const nextSession = parseSessionTimeET('2026-02-26', '03:00')
+
+    const result = calculateNextPollDelay(now, nextSession, defaultConfig, false)
+
+    // Clamped to 6 AM ET = 5h from now
+    const expectedMs = 5 * 60 * 60 * 1000
+    expect(result.delayMs).toBe(expectedMs)
+    expect(result.reason).toBe('sleep')
+  })
+
+  it('clamps interval-based wake to next active window when after pollEndHour', () => {
+    // now: Feb 20, 11:30 PM ET = Feb 21 04:30 UTC (inside approach window)
+    const now = new Date('2026-02-21T04:30:00Z')
+    const nextSession = parseSessionTimeET('2026-02-23', '19:00')
+
+    const result = calculateNextPollDelay(now, nextSession, defaultConfig, false)
+
+    // Normal interval would be 60 min → Feb 21 12:30 AM ET (hour 0)
+    // 0 < pollStartHour (6), clamp to 6 AM ET = Feb 21 11:00 UTC
+    // Delay = 11:00 - 04:30 = 6.5h
+    expect(result.delayMs).toBe(6.5 * 60 * 60 * 1000)
+    expect(result.reason).toBe('approach')
+  })
+
+  it('uses earliest session when multiple sessions upcoming', () => {
+    const now = new Date('2026-02-20T15:00:00Z') // Feb 20, 10 AM ET
+    // Two sessions: Feb 24 7PM ET and Feb 27 7PM ET
+    // getNextSessionTime picks Feb 24 — approach opens 9h from now
+    // calculateNextPollDelay takes the already-resolved next session time
+    const earlierSession = parseSessionTimeET('2026-02-24', '19:00')
+
+    const result = calculateNextPollDelay(now, earlierSession, defaultConfig, false)
+
+    expect(result.delayMs).toBe(9 * 60 * 60 * 1000)
+    expect(result.reason).toBe('sleep')
+  })
+
+  it('clamps fallback wake to active hours', () => {
+    // now: Feb 20, 11 PM ET = Feb 21 04:00 UTC
+    const now = new Date('2026-02-21T04:00:00Z')
+    // No sessions (fallback). Max sleep 12h → Feb 21 16:00 UTC = Feb 21 11 AM ET
+    // 11 AM ET is within active hours, no clamping needed. This test verifies that.
+
+    const result = calculateNextPollDelay(now, null, defaultConfig, false)
+
+    expect(result.delayMs).toBe(12 * 60 * 60 * 1000)
+    expect(result.reason).toBe('fallback')
+  })
+
+  it('clamps fallback wake to pollStartHour when it lands before active hours', () => {
+    // now: Feb 20, 8 PM ET = Feb 21 01:00 UTC
+    const now = new Date('2026-02-21T01:00:00Z')
+    // No sessions. Max sleep 12h → Feb 21 13:00 UTC = Feb 21 8 AM ET
+    // 8 AM is within active hours. Let me make max sleep shorter:
+    const config = { ...defaultConfig, maxSleepHours: 4 }
+    // now + 4h = Feb 21 05:00 UTC = Feb 21 midnight ET → before pollStartHour (6)
+    // Clamp to 6 AM ET = Feb 21 11:00 UTC → 10h from now
+
+    const result = calculateNextPollDelay(now, null, config, false)
+
+    expect(result.delayMs).toBe(10 * 60 * 60 * 1000)
+    expect(result.reason).toBe('fallback')
+  })
+
+  describe('log messages', () => {
+    it('includes session time in sleep message', () => {
+      const now = new Date('2026-02-20T15:00:00Z')
+      const nextSession = parseSessionTimeET('2026-02-25', '19:00')
+
+      const result = calculateNextPollDelay(now, nextSession, defaultConfig, false)
+
+      expect(result.scheduleLog).toContain('No sessions in approach window')
+      expect(result.scheduleLog).toContain('ET')
+    })
+
+    it('includes approach window message for active polling', () => {
+      const now = new Date('2026-02-20T15:00:00Z')
+      const nextSession = parseSessionTimeET('2026-02-23', '19:00')
+
+      const result = calculateNextPollDelay(now, nextSession, defaultConfig, false)
+
+      expect(result.scheduleLog).toContain('Approach window open')
+      expect(result.scheduleLog).toContain('60 minutes')
+    })
+
+    it('includes accelerated in message when FILLING_FAST', () => {
+      const now = new Date('2026-02-20T15:00:00Z')
+      const nextSession = parseSessionTimeET('2026-02-23', '19:00')
+
+      const result = calculateNextPollDelay(now, nextSession, defaultConfig, true)
+
+      expect(result.scheduleLog).toContain('30 minutes')
+      expect(result.scheduleLog).toContain('accelerated')
+    })
+
+    it('includes max sleep reached in fallback wake message', () => {
+      const now = new Date('2026-02-20T15:00:00Z')
+
+      const result = calculateNextPollDelay(now, null, defaultConfig, false)
+
+      expect(result.wakeLog).toContain('Max sleep reached')
+      expect(result.wakeLog).toContain('12h')
+    })
+
+    it('includes approach window open in sleep wake message', () => {
+      const now = new Date('2026-02-20T15:00:00Z')
+      // Session close enough that approach window is within max sleep
+      const nextSession = parseSessionTimeET('2026-02-24', '19:00')
+
+      const result = calculateNextPollDelay(now, nextSession, defaultConfig, false)
+
+      expect(result.wakeLog).toContain('Approach window open')
+    })
+  })
+})


### PR DESCRIPTION
Replaces fixed-interval polling with session-proximity-aware scheduling. The agent now sleeps longer when no sessions are imminent and wakes up precisely when it needs to begin active polling.

New module `src/poll-schedule.ts` with pure scheduling functions (parseSessionTimeET, getNextSessionTime, calculateNextPollDelay). New config fields: approachWindowHours (default 96h) and maxSleepHours (default 12h). Updated scheduler to use the new calculator and removed redundant active-hours checking.

Comprehensive test coverage for all scheduling scenarios (334 lines). All existing tests pass.